### PR TITLE
381518: Added a new pipeline variable for Team Name

### DIFF
--- a/.azuredevops/build.yaml
+++ b/.azuredevops/build.yaml
@@ -37,7 +37,7 @@ resources:
 extends:
   template: /pipelines/common-app-build.yaml@DEFRA-ADPPipelineCommon
   parameters:
-    projectName: "core-ai-techradar"
+    teamName: "crai-mcu"
     serviceName: "core-ai-techradar"
     deployFromFeature: ${{ parameters.deployFromFeature }}
     appBuildConfig:

--- a/.azuredevops/build.yaml
+++ b/.azuredevops/build.yaml
@@ -54,5 +54,4 @@ extends:
       # TO BE ADDED IF THERE ARE ANY KEYVAULT REFERENCES IN APP CONFIG
       variableGroups: 
         - core-ai-techradar-<environment>
-      variables:  # FILTER FOR SECRETS IN THE VARIABLE GROUP
-        - core-ai-techradar-APPINSIGHTS-CONNECTIONSTRING
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-ai-techradar",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Techradar to track AI technology assessments",
   "homepage": "https://github.com/DEFRA/aiunit-tech-radar",
   "main": "app/index.js",

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+If this PR closes an issue, add '<AB#213700>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. AB#213700 (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->
+
+# **What this PR does / why we need it**:
+*A brief description of changes being made*
+*Link to the relevant work items: e.g: Relates to ADO Work Item AB#213700 and builds on #3376 (link to ADO Build ID URL)*
+
+# **Special notes for your reviewer**
+*Any specific actions or notes on review?*
+
+# Testing
+*Any relevant testing information and pipeline runs.*
+
+# Checklist (please delete before completing or setting auto-complete)
+- [ ] Story Work items associated (not Tasks)
+- [ ] Successful testing run(s) link provided
+- [ ] Title pattern should be `{work item number}: {title}`
+- [ ] Description covers all the changes in the PR
+- [ ] This PR contains documentation
+- [ ] This PR contains tests
+
+
+# **How does this PR make you feel**:
+![gif]([https://giphy.com/)


### PR DESCRIPTION
- Added team name variable that is used when scaffolding flux manifests
- Removed projectName variable, no longer needed
- Removed variables section from ADO YAML pipeline, no longer required if you want to import all secrets from a variable group
- Related work item AB#381518